### PR TITLE
solve bug that detects wrong frequency with data-forwarder

### DIFF
--- a/cli/data-forwarder.ts
+++ b/cli/data-forwarder.ts
@@ -585,7 +585,7 @@ async function getSensorInfo(serial: SerialConnector, desiredFrequency: number |
     serial.off('data', onData);
 
     const data = Buffer.concat(dataBuffers);
-    let lines = data.toString('utf-8').split('\n').map(d => d.trim());
+    let lines = data.toString('utf-8').split('\n').map(d => d.trim()).filter(d => d.length);
 
     let l = lines[1]; // we take 1 here because 0 could have been truncated
     if (!l) {

--- a/cli/data-forwarder.ts
+++ b/cli/data-forwarder.ts
@@ -585,7 +585,7 @@ async function getSensorInfo(serial: SerialConnector, desiredFrequency: number |
     serial.off('data', onData);
 
     const data = Buffer.concat(dataBuffers);
-    let lines = data.toString('utf-8').split('\n').map(d => d.trim()).filter(d => d.length);
+    let lines = data.toString('utf-8').split('\n').map(d => d.trim()).slice(0,-1);
 
     let l = lines[1]; // we take 1 here because 0 could have been truncated
     if (!l) {


### PR DESCRIPTION
When using the `edge-impulse-data-forwarder` command it will try to detect the data frequency automatically. The detected frequency is always wrong and off by a value of 1.

Together with (@jonaslannoo)  we tested this with different frequencies, ranging from 2 till 100Hz, and the detected value is always 1 larger than the real value. We measured the real values using an oscilloscope and defined datarates using crystal operated microcontrollers (32.768kHz +/- 175ppm ~ 99.5%).

The problem lies within the implementation. In order to detect the frequency, the number of lines (`\n` characters) in a given time are counted. Before counting, the `String.prototype.split()` method is used to convert the input buffer into an array of lines. The problem with this method is that the last item of this array will contain the part of the buffer/string that was after the last newline character. In most cases this is just an empty string. This empty string should be ignored before counting lines as it does not contain any data.

I created a example to illustrate this behavior:
```javascript
// example data that contains 3 lines of data, delimited by a \n character
const data = "39,-1033,117\n39,-1033,117\n35,-1036,117\n"
const lines = data.split("\n")

console.log(lines)          // [ '39,-1033,117', '39,-1033,117', '35,-1036,117', '' ]
console.log(lines.length)   // 4
```

This issue occurs in `Edge Impulse data forwarder v1.13.10`

A `Array.prototype.filter()` could solve this problem by filtering out all Strings that do not have a length.

```javascript
const data = "39,-1033,117\n39,-1033,117\n35,-1036,117\n"
let lines = data.split("\n")

// filter out strings that do not have a length
lines = lines.filter(d => d.length)

console.log(lines)          // [ '39,-1033,117', '39,-1033,117', '35,-1036,117' ]
console.log(lines.length)   // 3
```