### PR TITLE
Check for a dotfile config, fallback to before

### DIFF
--- a/cli/config.ts
+++ b/cli/config.ts
@@ -103,7 +103,9 @@ export class Config {
     private _configured = false;
 
     constructor() {
-        this._filename = Path.join(os.homedir(), 'edge-impulse-config.json');
+        const filename = Path.join(os.homedir(), 'edge-impulse-config.json');
+        const dotfilename = Path.join(os.homedir(), '.edge-impulse-config.json');
+        this._filename = (await Config.exists(dotfilename)) ? dotfilename : filename;
     }
 
     /**


### PR DESCRIPTION
Configuration files are normally dotfiles – filename preceded by a dot to hide from GUI – but Edge Impulse breaks this convention since its config file is located at `~/edge-impulse-config.json` rather than `~/.edge-impulse-config.json`. This updates the constructor function in `config.ts` to look for a hidden dotfile config before falling back to the non hidden config file. This should hopefully let those that care convert the Edge Impulse config file into a dotfile while not affecting others.

note: this is very much a naive simple approach as I'm unfamiliar with the entirety of this CLI