### PR TITLE
add serial port options to daemon

### DIFF
--- a/cli/daemon.ts
+++ b/cli/daemon.ts
@@ -38,6 +38,8 @@ const baudRateArgvIx = process.argv.indexOf('--baud-rate');
 const baudRateArgv = baudRateArgvIx !== -1 ? process.argv[baudRateArgvIx + 1] : undefined;
 const whichDeviceArgvIx = process.argv.indexOf('--which-device');
 const whichDeviceArgv = whichDeviceArgvIx !== -1 ? Number(process.argv[whichDeviceArgvIx + 1]) : undefined;
+const serialPortArgvIx = process.argv.indexOf('--port');
+const serialPortArgv = serialPortArgvIx !== -1 ? process.argv[serialPortArgvIx + 1] : undefined;
 
 let configFactory: Config;
 let serial: SerialConnector | undefined;
@@ -474,7 +476,7 @@ class SerialDevice extends (EventEmitter as new () => TypedEmitter<{
         console.log('    Ingestion:', config.endpoints.internal.ingestion);
         console.log('');
 
-        let deviceId = await findSerial(whichDeviceArgv);
+        let deviceId = serialPortArgv || await findSerial(whichDeviceArgv);
         await connectToSerial(config, deviceId, baudRate, (cleanArgv || apiKeyArgv) ? true : false);
     }
     catch (ex) {


### PR DESCRIPTION
I ran into issues when I was working with the ESP32-CAM board. My mac detected multiple serial ports, but only one worked, and the others were always busy. But the CLI constantly used the one that wasn't working, and I realized there was no way to select the serial port manually.

This pull request aims to provide that feature.